### PR TITLE
Fix Uninitialised SyncFilterParameter Value

### DIFF
--- a/dotmimsync/src/main/java/com/mimetis/dotmim/sync/set/SyncFilterParameter.kt
+++ b/dotmimsync/src/main/java/com/mimetis/dotmim/sync/set/SyncFilterParameter.kt
@@ -35,7 +35,7 @@ class SyncFilterParameter(
          * Gets or Sets the parameter db type
          */
         @SerialName("dt")
-        var dbType: DbType?,
+        var dbType: DbType? = null,
 
         /**
          * Gets or Sets the parameter default value expression.


### PR DESCRIPTION
When using non-custom filter parameters the server does not send a type for the parameter causing a serialization error when received since there is no default value.